### PR TITLE
Use  GOPROXY=direct for update-sdk.yaml

### DIFF
--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.13
       - name: Update sdk locally
         run: |
-          go get -u github.com/networkservicemesh/api
+          GOPROXY=direct go get -u github.com/networkservicemesh/api
           go mod tidy
           git diff
       - name: Push update to sdk


### PR DESCRIPTION
Turns out that sometimes the google go module proxy isn't
quick about getting updated from github.com.  Since obviously
we *want* to get this right, we use  GOPROXY=direct to force
it to go to the direct source.