### PR TITLE
Add initialisms check to golangci-lint

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,10 @@
+checks = ["all", "-ST1000", "-ST1016"]
+initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS",
+	"EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID",
+	"IP", "JSON", "NS", "NSM", "QPS", "RAM", "RPC", "SLA",
+	"SMTP", "SQL", "SSH", "TCP", "TLS", "TTL",
+	"UDP", "UI", "GID", "UID", "UUID", "URI",
+	"URL", "UTF8", "VM", "XML", "XMPP", "XSRF",
+	"XSS"]
+dot_import_whitelist = []
+http_status_code_whitelist = ["200", "400", "404", "500"]


### PR DESCRIPTION
Example output on master branch before merge of #11:
```
pkg/api/connection/mechanisms/common/constants.go:26:2: ST1003: const NetNsInodeKey should be NetNSInodeKey (stylecheck)
        NetNsInodeKey = "netnsInode"
        ^
pkg/api/connection/mechanisms/kernel/constants.go:39:2: ST1003: const NsmBaseDirEnv should be NSMBaseDirEnv (stylecheck)
        NsmBaseDirEnv = "NSM_BASE_DIR"
        ^
pkg/api/connection/mechanisms/kernel/helpers.go:54:21: ST1003: method GetNetNsInode should be GetNetNSInode (stylecheck)
func (m *mechanism) GetNetNsInode() string { 
                    ^
pkg/api/connection/mechanisms/memif/helpers.go:64:21: ST1003: method GetNetNsInode should be GetNetNSInode (stylecheck)
func (m *mechanism) GetNetNsInode() string { 
                    ^
```