### PR TITLE
Rename SRIOV_USERSPACE to vfio.

### DIFF
--- a/pkg/api/networkservice/mechanisms/vfio/constants.go
+++ b/pkg/api/networkservice/mechanisms/vfio/constants.go
@@ -14,12 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sriovuserspace provides a Mechanism for using sriov NICs in userspace.
-package sriovuserspace
+// Package vfio provides a Mechanism for using vfio devices.
+package vfio
 
 const (
 	// MECHANISM string
-	MECHANISM = "SRIOV_USERSPACE"
+	MECHANISM = "VFIO"
 
 	// Mechanism parameters
 

--- a/pkg/api/networkservice/mechanisms/vfio/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vfio/helpers.go
@@ -14,14 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sriovuserspace
+package vfio
 
 import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
 )
 
-// Mechanism - SRIOV userspace interface mechanism helper
+// Mechanism - vfio mechanism helper
 type Mechanism interface {
 	GetNetNSInode() string
 	GetParameters() map[string]string


### PR DESCRIPTION
Putting this out there as a draft for discussion on naming.  I look to folks who know this space better to tell me whether this is a good idea or a bad one :)