### PR TITLE
Small fix to mechanisms/vxlan

### DIFF
--- a/pkg/api/networkservice/mechanisms/vxlan/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vxlan/helpers.go
@@ -41,7 +41,7 @@ type mechanism struct {
 
 // ToMechanism - convert unified mechanism to useful wrapper
 func ToMechanism(m *networkservice.Mechanism) Mechanism {
-	if m.Type == MECHANISM {
+	if m.GetType() == MECHANISM {
 		return &mechanism{
 			m,
 		}


### PR DESCRIPTION
Replace m.Type with m.GetType() to make us panic safe.