### PR TITLE
Update setup-protoc step for job 'Check protobuf generation'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: arduino/actions/setup-protoc@master
+      - uses: arduino/setup-protoc@master
         with:
           version: '3.8.0'
       - uses: actions/setup-go@v1


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

Setup protoc action https://github.com/arduino/setup-protoc has moved from `arduino/actions/setup-protoc@master` to `arduino/setup-protoc@master`