### PR TITLE
Unify Src/Dst Port handling across remote mechanisms

### DIFF
--- a/pkg/api/networkservice/mechanisms/common/constants.go
+++ b/pkg/api/networkservice/mechanisms/common/constants.go
@@ -23,6 +23,11 @@ const (
 	// DstIP - key for DstIP parameters
 	DstIP = "dst_ip"
 
+	// SrcPort - key for SrcPort parameters
+	SrcPort = "src_port"
+	// DstPort - ley for DstPort parameters
+	DstPort = "dst_port"
+
 	// SrcOriginalIP - original src IP
 	SrcOriginalIP = "orig_src_ip"
 	// DstExternalIP - external destination ip

--- a/pkg/api/networkservice/mechanisms/vxlan/constant.go
+++ b/pkg/api/networkservice/mechanisms/vxlan/constant.go
@@ -29,8 +29,12 @@ const (
 
 	// SrcIP - source IP
 	SrcIP = common.SrcIP
-	// DstIP - destitiona IP
+	// DstIP - destination IP
 	DstIP = common.DstIP
+	// SrcPort - Source vxlan listening port
+	SrcPort = common.SrcPort
+	// DstPort - Destination vxlan listening port
+	DstPort = common.DstPort
 	// SrcOriginalIP - original src IP
 	SrcOriginalIP = common.SrcOriginalIP
 	// DstExternalIP - external destination ip

--- a/pkg/api/networkservice/mechanisms/vxlan/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vxlan/helpers.go
@@ -193,3 +193,39 @@ func (m *Mechanism) SetMTU(mtu uint32) *Mechanism {
 
 	return m
 }
+
+// SrcPort - Source vxlan listening port
+func (m *Mechanism) SrcPort() uint16 {
+	port, err := strconv.ParseUint(m.GetParameters()[SrcPort], 10, 16)
+	if err != nil {
+		return 0
+	}
+	return uint16(port)
+}
+
+// SetSrcPort - Set source vxlan listening port
+func (m *Mechanism) SetSrcPort(port uint16) *Mechanism {
+	if m == nil {
+		return nil
+	}
+	m.GetParameters()[SrcPort] = strconv.FormatUint(uint64(port), 10)
+	return m
+}
+
+// DstPort - Destination vxlan listening port
+func (m *Mechanism) DstPort() uint16 {
+	port, err := strconv.ParseUint(m.GetParameters()[DstPort], 10, 16)
+	if err != nil {
+		return 0
+	}
+	return uint16(port)
+}
+
+// SetDstPort - Set destination vxlan listening port
+func (m *Mechanism) SetDstPort(port uint16) *Mechanism {
+	if m == nil {
+		return nil
+	}
+	m.GetParameters()[DstPort] = strconv.FormatUint(uint64(port), 10)
+	return m
+}

--- a/pkg/api/networkservice/mechanisms/wireguard/constant.go
+++ b/pkg/api/networkservice/mechanisms/wireguard/constant.go
@@ -28,16 +28,16 @@ const (
 
 	// SrcIP - source IP
 	SrcIP = common.SrcIP
-	// DstIP - destitiona IP
+	// DstIP - destination IP
 	DstIP = common.DstIP
 	// SrcOriginalIP - original src IP
-	SrcOriginalIP = "orig_src_ip"
+	SrcOriginalIP = common.SrcOriginalIP
 	// DstExternalIP - external destination ip
-	DstExternalIP = "ext_src_ip"
+	DstExternalIP = common.DstExternalIP
 	// SrcPort - Source interface listening port
-	SrcPort = "src_port"
+	SrcPort = common.SrcPort
 	// DstPort - Destination interface listening port
-	DstPort = "dst_port"
+	DstPort = common.DstPort
 	// SrcPublicKey - Source public key
 	SrcPublicKey = "src_public_key"
 	// DstPublicKey - Destination public key


### PR DESCRIPTION
Also cleaned up wireguard to use common.* parameters when possibe.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
