### PR TITLE
fix: push tag on a release branch before creating release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'release/') }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with: 
+          ref: refs/heads/${{github.event.workflow_run.head_branch}}
       - name: Get tag
         run: |
           branch=${{github.event.workflow_run.head_branch}}
           echo '::set-output name=tag::'${branch#release/}
         id: get-tag-step
-      - name: Create Release
+      - name: Push tag ${{ steps.get-tag-step.outputs.tag }}
+        run: |
+          git status
+          git tag ${{ steps.get-tag-step.outputs.tag }}
+          git push origin ${{ steps.get-tag-step.outputs.tag }} -f
+      - name: Create release ${{ steps.get-tag-step.outputs.tag }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
@@ -46,13 +55,6 @@ jobs:
           branch=${{github.event.workflow_run.head_branch}}
           echo '::set-output name=tag::'${branch#release/}
         id: get-tag-step
-      - name: Delete exist tag and release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
-        with:
-          delete_release: true
-          tag_name: ${{ steps.get-tag-step.outputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - name: Create commit
         run: |
           echo "Update go.mod and go.sum to ${{ github.repository }}@${{ steps.get-tag-step.outputs.tag }}" >> /tmp/commit-message

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with: 
+        with:
           ref: refs/heads/${{github.event.workflow_run.head_branch}}
       - name: Get tag
         run: |


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Problem

By default actions/create-release@v1 creates tags based always on the default branch. It can affect NSM release.

## Solution

Create a tag on a required branch before doing the release.