### PR TITLE
[sdk-vpp#314] Add SR-IOV token ID mechanism parameter for kernel, VFIO mechanisms

### DIFF
--- a/pkg/api/networkservice/mechanisms/common/constants.go
+++ b/pkg/api/networkservice/mechanisms/common/constants.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +47,10 @@ const (
 
 	// PCIAddressKey - PCI address of the device for the SR-IOV supported mechanisms
 	PCIAddressKey = "pciAddress"
+
+	// SRIOVTokenIDKey - Client/Endpoint SR-IOV token ID
+	// nolint:gosec
+	SRIOVTokenIDKey = "sriovTokenID"
 
 	// MTU - Maximum Transmission Unit
 	MTU = "MTU"

--- a/pkg/api/networkservice/mechanisms/common/constants.go
+++ b/pkg/api/networkservice/mechanisms/common/constants.go
@@ -48,9 +48,9 @@ const (
 	// PCIAddressKey - PCI address of the device for the SR-IOV supported mechanisms
 	PCIAddressKey = "pciAddress"
 
-	// TokenIDKey - Client/Endpoint token ID
+	// DeviceTokenIDKey - Client/Endpoint device token ID
 	// nolint:gosec
-	TokenIDKey = "tokenID"
+	DeviceTokenIDKey = "tokenID"
 
 	// MTU - Maximum Transmission Unit
 	MTU = "MTU"

--- a/pkg/api/networkservice/mechanisms/common/constants.go
+++ b/pkg/api/networkservice/mechanisms/common/constants.go
@@ -48,9 +48,9 @@ const (
 	// PCIAddressKey - PCI address of the device for the SR-IOV supported mechanisms
 	PCIAddressKey = "pciAddress"
 
-	// SRIOVTokenIDKey - Client/Endpoint SR-IOV token ID
+	// TokenIDKey - Client/Endpoint token ID
 	// nolint:gosec
-	SRIOVTokenIDKey = "sriovTokenID"
+	TokenIDKey = "tokenID"
 
 	// MTU - Maximum Transmission Unit
 	MTU = "MTU"

--- a/pkg/api/networkservice/mechanisms/kernel/constants.go
+++ b/pkg/api/networkservice/mechanisms/kernel/constants.go
@@ -35,8 +35,8 @@ const (
 	// PCIAddressKey - device PCI address property key
 	PCIAddressKey = common.PCIAddressKey
 
-	// SRIOVTokenIDKey is a SR-IOV token ID property key
-	SRIOVTokenIDKey = common.SRIOVTokenIDKey
+	// TokenIDKey is a token ID property key
+	TokenIDKey = common.TokenIDKey
 
 	// NetNSInodeKey - netns inode mechanism property key
 	NetNSInodeKey = common.NetNSInodeKey

--- a/pkg/api/networkservice/mechanisms/kernel/constants.go
+++ b/pkg/api/networkservice/mechanisms/kernel/constants.go
@@ -35,8 +35,8 @@ const (
 	// PCIAddressKey - device PCI address property key
 	PCIAddressKey = common.PCIAddressKey
 
-	// TokenIDKey is a token ID property key
-	TokenIDKey = common.TokenIDKey
+	// DeviceTokenIDKey is a device token ID property key
+	DeviceTokenIDKey = common.DeviceTokenIDKey
 
 	// NetNSInodeKey - netns inode mechanism property key
 	NetNSInodeKey = common.NetNSInodeKey

--- a/pkg/api/networkservice/mechanisms/kernel/constants.go
+++ b/pkg/api/networkservice/mechanisms/kernel/constants.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +34,9 @@ const (
 
 	// PCIAddressKey - device PCI address property key
 	PCIAddressKey = common.PCIAddressKey
+
+	// SRIOVTokenIDKey is a SR-IOV token ID property key
+	SRIOVTokenIDKey = common.SRIOVTokenIDKey
 
 	// NetNSInodeKey - netns inode mechanism property key
 	NetNSInodeKey = common.NetNSInodeKey

--- a/pkg/api/networkservice/mechanisms/kernel/helpers.go
+++ b/pkg/api/networkservice/mechanisms/kernel/helpers.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2019-2021 Cisco Systems, Inc and/or its affiliates.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,6 +86,16 @@ func (m *Mechanism) SetPCIAddress(pciAddress string) {
 // IsPCIDevice returns if this mechanism is for a PCI device
 func (m *Mechanism) IsPCIDevice() bool {
 	return m.GetPCIAddress() != ""
+}
+
+// GetSRIOVTokenID returns SR-IOV token ID
+func (m *Mechanism) GetSRIOVTokenID() string {
+	return m.Parameters[SRIOVTokenIDKey]
+}
+
+// SetSRIOVTokenID sets SR-IOV token ID
+func (m *Mechanism) SetSRIOVTokenID(tokenID string) {
+	m.Parameters[SRIOVTokenIDKey] = tokenID
 }
 
 // GetInterfaceName returns the Kernel Interface Name

--- a/pkg/api/networkservice/mechanisms/kernel/helpers.go
+++ b/pkg/api/networkservice/mechanisms/kernel/helpers.go
@@ -88,14 +88,14 @@ func (m *Mechanism) IsPCIDevice() bool {
 	return m.GetPCIAddress() != ""
 }
 
-// GetSRIOVTokenID returns SR-IOV token ID
-func (m *Mechanism) GetSRIOVTokenID() string {
-	return m.Parameters[SRIOVTokenIDKey]
+// GetTokenID returns token ID
+func (m *Mechanism) GetTokenID() string {
+	return m.Parameters[TokenIDKey]
 }
 
-// SetSRIOVTokenID sets SR-IOV token ID
-func (m *Mechanism) SetSRIOVTokenID(tokenID string) {
-	m.Parameters[SRIOVTokenIDKey] = tokenID
+// SetTokenID sets token ID
+func (m *Mechanism) SetTokenID(tokenID string) {
+	m.Parameters[TokenIDKey] = tokenID
 }
 
 // GetInterfaceName returns the Kernel Interface Name

--- a/pkg/api/networkservice/mechanisms/kernel/helpers.go
+++ b/pkg/api/networkservice/mechanisms/kernel/helpers.go
@@ -88,14 +88,14 @@ func (m *Mechanism) IsPCIDevice() bool {
 	return m.GetPCIAddress() != ""
 }
 
-// GetTokenID returns token ID
-func (m *Mechanism) GetTokenID() string {
-	return m.Parameters[TokenIDKey]
+// GetDeviceTokenID returns device token ID
+func (m *Mechanism) GetDeviceTokenID() string {
+	return m.Parameters[DeviceTokenIDKey]
 }
 
-// SetTokenID sets token ID
-func (m *Mechanism) SetTokenID(tokenID string) {
-	m.Parameters[TokenIDKey] = tokenID
+// SetDeviceTokenID sets device token ID
+func (m *Mechanism) SetDeviceTokenID(tokenID string) {
+	m.Parameters[DeviceTokenIDKey] = tokenID
 }
 
 // GetInterfaceName returns the Kernel Interface Name

--- a/pkg/api/networkservice/mechanisms/vfio/constants.go
+++ b/pkg/api/networkservice/mechanisms/vfio/constants.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 Intel Corporation. All Rights Reserved.
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,6 +35,9 @@ const (
 
 	// PCIAddressKey is a PCI address property key
 	PCIAddressKey = common.PCIAddressKey
+
+	// SRIOVTokenIDKey is a SR-IOV token ID property key
+	SRIOVTokenIDKey = common.SRIOVTokenIDKey
 
 	// VfioMajorKey is a /dev/vfio major number property key
 	VfioMajorKey = "vfioMajor"

--- a/pkg/api/networkservice/mechanisms/vfio/constants.go
+++ b/pkg/api/networkservice/mechanisms/vfio/constants.go
@@ -36,8 +36,8 @@ const (
 	// PCIAddressKey is a PCI address property key
 	PCIAddressKey = common.PCIAddressKey
 
-	// SRIOVTokenIDKey is a SR-IOV token ID property key
-	SRIOVTokenIDKey = common.SRIOVTokenIDKey
+	// TokenIDKey is a token ID property key
+	TokenIDKey = common.TokenIDKey
 
 	// VfioMajorKey is a /dev/vfio major number property key
 	VfioMajorKey = "vfioMajor"

--- a/pkg/api/networkservice/mechanisms/vfio/constants.go
+++ b/pkg/api/networkservice/mechanisms/vfio/constants.go
@@ -36,8 +36,8 @@ const (
 	// PCIAddressKey is a PCI address property key
 	PCIAddressKey = common.PCIAddressKey
 
-	// TokenIDKey is a token ID property key
-	TokenIDKey = common.TokenIDKey
+	// DeviceTokenIDKey is a device token ID property key
+	DeviceTokenIDKey = common.DeviceTokenIDKey
 
 	// VfioMajorKey is a /dev/vfio major number property key
 	VfioMajorKey = "vfioMajor"

--- a/pkg/api/networkservice/mechanisms/vfio/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vfio/helpers.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 Intel Corporation. All Rights Reserved.
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -89,6 +90,16 @@ func (m *Mechanism) GetPCIAddress() string {
 // SetPCIAddress sets PCI address
 func (m *Mechanism) SetPCIAddress(pciAddress string) {
 	m.GetParameters()[PCIAddressKey] = pciAddress
+}
+
+// GetSRIOVTokenID returns SR-IOV token ID
+func (m *Mechanism) GetSRIOVTokenID() string {
+	return m.Parameters[SRIOVTokenIDKey]
+}
+
+// SetSRIOVTokenID sets SR-IOV token ID
+func (m *Mechanism) SetSRIOVTokenID(tokenID string) {
+	m.Parameters[SRIOVTokenIDKey] = tokenID
 }
 
 // GetVfioMajor returns /dev/vfio major number

--- a/pkg/api/networkservice/mechanisms/vfio/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vfio/helpers.go
@@ -92,14 +92,14 @@ func (m *Mechanism) SetPCIAddress(pciAddress string) {
 	m.GetParameters()[PCIAddressKey] = pciAddress
 }
 
-// GetTokenID returns token ID
-func (m *Mechanism) GetTokenID() string {
-	return m.Parameters[TokenIDKey]
+// GetDeviceTokenID returns device token ID
+func (m *Mechanism) GetDeviceTokenID() string {
+	return m.Parameters[DeviceTokenIDKey]
 }
 
-// SetTokenID sets token ID
-func (m *Mechanism) SetTokenID(tokenID string) {
-	m.Parameters[TokenIDKey] = tokenID
+// SetDeviceTokenID sets device token ID
+func (m *Mechanism) SetDeviceTokenID(tokenID string) {
+	m.Parameters[DeviceTokenIDKey] = tokenID
 }
 
 // GetVfioMajor returns /dev/vfio major number

--- a/pkg/api/networkservice/mechanisms/vfio/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vfio/helpers.go
@@ -92,14 +92,14 @@ func (m *Mechanism) SetPCIAddress(pciAddress string) {
 	m.GetParameters()[PCIAddressKey] = pciAddress
 }
 
-// GetSRIOVTokenID returns SR-IOV token ID
-func (m *Mechanism) GetSRIOVTokenID() string {
-	return m.Parameters[SRIOVTokenIDKey]
+// GetTokenID returns token ID
+func (m *Mechanism) GetTokenID() string {
+	return m.Parameters[TokenIDKey]
 }
 
-// SetSRIOVTokenID sets SR-IOV token ID
-func (m *Mechanism) SetSRIOVTokenID(tokenID string) {
-	m.Parameters[SRIOVTokenIDKey] = tokenID
+// SetTokenID sets token ID
+func (m *Mechanism) SetTokenID(tokenID string) {
+	m.Parameters[TokenIDKey] = tokenID
 }
 
 // GetVfioMajor returns /dev/vfio major number


### PR DESCRIPTION
## Description
Adds SR-IOV token ID mechanism parameter for kernel, VFIO mechanisms.

Actually moves it from `sdk-sriov` to more relevant place.
https://github.com/networkservicemesh/sdk-sriov/blob/9a5f775aa79d492447aa58867b0a3218be78ff48/pkg/networkservice/common/resourcepool/common.go#L35-L36

## Issue link
Needed for networkservicemesh/sdk-vpp#314.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
