### PR TITLE
[sdk-vpp#370] Change memif to work with abstract sockets

### DIFF
--- a/pkg/api/networkservice/mechanisms/common/constants.go
+++ b/pkg/api/networkservice/mechanisms/common/constants.go
@@ -42,7 +42,7 @@ const (
 	// InterfaceNameKey - interface name mechanism property key
 	InterfaceNameKey = "name"
 
-	// InodeURL - url of the for inode://${dev}/${ino} to represent various netns, memif socket files etc
+	// InodeURL - file:// or inode:// URL representing some file shared between processes with grpcfd (e.g. netns file)
 	InodeURL = "inodeURL"
 
 	// PCIAddressKey - PCI address of the device for the SR-IOV supported mechanisms

--- a/pkg/api/networkservice/mechanisms/kernel/constants.go
+++ b/pkg/api/networkservice/mechanisms/kernel/constants.go
@@ -44,7 +44,9 @@ const (
 	// InterfaceNameKey - interface name mechanism property key
 	InterfaceNameKey = common.InterfaceNameKey
 
-	// NetNSURL - url representing an inode - fmt.Sprintf("inode://%d/%d",dev,ino)
+	// NetNSURL - NetNS URL, it can be either:
+	// * file:///proc/${pid}/ns/net - ${pid} process net NS
+	// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
 	NetNSURL = common.InodeURL
 
 	// NetNSURLScheme - expected scheme of NetNSURLs

--- a/pkg/api/networkservice/mechanisms/kernel/helpers.go
+++ b/pkg/api/networkservice/mechanisms/kernel/helpers.go
@@ -31,7 +31,7 @@ type Mechanism struct {
 	*networkservice.Mechanism
 }
 
-// New returns *networkservice.Mechanism of type kernel using the given netnsURL (inode://${dev}/${ino})
+// New returns *networkservice.Mechanism of type kernel using the given netnsURL (file:///proc/${pid}/ns/net)
 func New(netnsURL string) *networkservice.Mechanism {
 	return &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
@@ -43,6 +43,7 @@ func New(netnsURL string) *networkservice.Mechanism {
 }
 
 // ToMechanism converts unified mechanism to helper
+// If Mechanism m is *not* of type kernel.MECHANISM, it returns nil
 func ToMechanism(m *networkservice.Mechanism) *Mechanism {
 	if m.GetType() == MECHANISM {
 		return &Mechanism{
@@ -108,12 +109,14 @@ func (m *Mechanism) SetInterfaceName(interfaceName string) {
 	m.GetParameters()[InterfaceNameKey] = interfaceName
 }
 
-// GetNetNSURL returns the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+// GetNetNSURL returns the NetNS URL, it can be either:
+// * file:///proc/${pid}/ns/net - ${pid} process net NS
+// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
 func (m *Mechanism) GetNetNSURL() string {
 	return m.GetParameters()[NetNSURL]
 }
 
-// SetNetNSURL sets the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+// SetNetNSURL sets the NetNS URL - file:///proc/${pid}/ns/net
 func (m *Mechanism) SetNetNSURL(urlString string) {
 	m.GetParameters()[NetNSURL] = urlString
 }

--- a/pkg/api/networkservice/mechanisms/memif/constants.go
+++ b/pkg/api/networkservice/mechanisms/memif/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2021 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,9 +29,9 @@ const (
 	// SocketFilename - name of the memif socketfile
 	SocketFilename = "socketfile"
 
-	// SocketFileURL - file url for the memif socketfile
-	SocketFileURL = common.InodeURL
+	// NetNSURL - url representing a inode - fmt.Sprintf("inode://%d/%d",dev,ino)
+	NetNSURL = common.InodeURL
 
-	// SocketFileScheme - expected scheme of the SocketFileURL
+	// SocketFileScheme - expected scheme of the NetNSURL
 	SocketFileScheme = "file"
 )

--- a/pkg/api/networkservice/mechanisms/memif/constants.go
+++ b/pkg/api/networkservice/mechanisms/memif/constants.go
@@ -29,9 +29,11 @@ const (
 	// SocketFilename - name of the memif socketfile
 	SocketFilename = "socketfile"
 
-	// NetNSURL - url representing a inode - fmt.Sprintf("inode://%d/%d",dev,ino)
+	// NetNSURL - NetNS URL, it can be either:
+	// * file:///proc/${pid}/ns/net - ${pid} process net NS
+	// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
 	NetNSURL = common.InodeURL
 
-	// SocketFileScheme - expected scheme of the NetNSURL
-	SocketFileScheme = "file"
+	// NetNSFileScheme - expected scheme of the NetNSURL
+	NetNSFileScheme = "file"
 )

--- a/pkg/api/networkservice/mechanisms/memif/constants.go
+++ b/pkg/api/networkservice/mechanisms/memif/constants.go
@@ -26,14 +26,19 @@ const (
 
 	// Mechanism parameters
 
-	// SocketFilename - name of the memif socketfile
+	// SocketFilename - [abstract sockets case] name of the memif socketfile
 	SocketFilename = "socketfile"
 
-	// NetNSURL - NetNS URL, it can be either:
+	// NetNSURL - [abstract sockets case] NetNS URL, it can be either:
 	// * file:///proc/${pid}/ns/net - ${pid} process net NS
 	// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
 	NetNSURL = common.InodeURL
 
-	// NetNSFileScheme - expected scheme of the NetNSURL
-	NetNSFileScheme = "file"
+	// SocketFileURL - [FS sockets case] memif socketfile URL, it can be either:
+	// * file://${path} - memif socketfile
+	// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
+	SocketFileURL = common.InodeURL
+
+	// FileScheme - expected scheme of the NetNSURL, SocketFileURL
+	FileScheme = "file"
 )

--- a/pkg/api/networkservice/mechanisms/memif/helpers.go
+++ b/pkg/api/networkservice/mechanisms/memif/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Cisco Systems, Inc.
+// Copyright (c) 2019-2021 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,8 +18,6 @@
 package memif
 
 import (
-	"net/url"
-
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 )
@@ -29,14 +27,13 @@ type Mechanism struct {
 	*networkservice.Mechanism
 }
 
-// New returns *networkservice.Mechanism of type  memif using the given socketPath (file://socketPath)
-func New(socketPath string) *networkservice.Mechanism {
+// New returns *networkservice.Mechanism of type  memif using the given netnsURL (inode://${dev}/${ino})
+func New(netnsURL string) *networkservice.Mechanism {
 	return &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
 		Type: MECHANISM,
 		Parameters: map[string]string{
-			SocketFilename: socketPath,
-			SocketFileURL:  (&url.URL{Scheme: SocketFileScheme, Path: socketPath}).String(),
+			NetNSURL: netnsURL,
 		},
 	}
 }
@@ -65,18 +62,20 @@ func (m *Mechanism) GetParameters() map[string]string {
 
 // GetSocketFilename returns memif mechanism socket filename
 func (m *Mechanism) GetSocketFilename() string {
-	if m == nil || m.GetParameters() == nil {
-		return ""
-	}
 	return m.GetParameters()[SocketFilename]
 }
 
-// GetSocketFileURL returns the SocketFileURL
-func (m *Mechanism) GetSocketFileURL() string {
-	return m.GetParameters()[SocketFileURL]
+// SetSocketFilename sets memif mechanism socket filename
+func (m *Mechanism) SetSocketFilename(filename string) {
+	m.GetParameters()[SocketFilename] = filename
 }
 
-// SetSocketFileURL sets the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
-func (m *Mechanism) SetSocketFileURL(urlString string) {
-	m.GetParameters()[SocketFileURL] = urlString
+// GetNetNSURL returns the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+func (m *Mechanism) GetNetNSURL() string {
+	return m.GetParameters()[NetNSURL]
+}
+
+// SetNetNSURL sets the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+func (m *Mechanism) SetNetNSURL(urlString string) {
+	m.GetParameters()[NetNSURL] = urlString
 }

--- a/pkg/api/networkservice/mechanisms/memif/helpers.go
+++ b/pkg/api/networkservice/mechanisms/memif/helpers.go
@@ -18,6 +18,8 @@
 package memif
 
 import (
+	"net/url"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 )
@@ -27,13 +29,24 @@ type Mechanism struct {
 	*networkservice.Mechanism
 }
 
-// New returns *networkservice.Mechanism of type memif using the given netnsURL (file:///proc/${pid}/ns/net)
-func New(netnsURL string) *networkservice.Mechanism {
+// New returns *networkservice.Mechanism of type memif using the given socketPath
+func New(socketPath string) *networkservice.Mechanism {
 	return &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
 		Type: MECHANISM,
 		Parameters: map[string]string{
-			NetNSURL: netnsURL,
+			SocketFileURL: (&url.URL{Scheme: FileScheme, Path: socketPath}).String(),
+		},
+	}
+}
+
+// NewAbstract returns *networkservice.Mechanism of type memif using the given netNSPath
+func NewAbstract(netNSPath string) *networkservice.Mechanism {
+	return &networkservice.Mechanism{
+		Cls:  cls.LOCAL,
+		Type: MECHANISM,
+		Parameters: map[string]string{
+			NetNSURL: (&url.URL{Scheme: FileScheme, Path: netNSPath}).String(),
 		},
 	}
 }

--- a/pkg/api/networkservice/mechanisms/memif/helpers.go
+++ b/pkg/api/networkservice/mechanisms/memif/helpers.go
@@ -27,7 +27,7 @@ type Mechanism struct {
 	*networkservice.Mechanism
 }
 
-// New returns *networkservice.Mechanism of type  memif using the given netnsURL (inode://${dev}/${ino})
+// New returns *networkservice.Mechanism of type memif using the given netnsURL (file:///proc/${pid}/ns/net)
 func New(netnsURL string) *networkservice.Mechanism {
 	return &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
@@ -70,12 +70,14 @@ func (m *Mechanism) SetSocketFilename(filename string) {
 	m.GetParameters()[SocketFilename] = filename
 }
 
-// GetNetNSURL returns the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+// GetNetNSURL returns the NetNS URL, it can be either:
+// * file:///proc/${pid}/ns/net - ${pid} process net NS
+// * inode://${dev}/${ino} - while transferring file between processes using grpcfd
 func (m *Mechanism) GetNetNSURL() string {
 	return m.GetParameters()[NetNSURL]
 }
 
-// SetNetNSURL sets the NetNS URL - fmt.Sprintf("inode://%d/%d",dev,ino)
+// SetNetNSURL sets the NetNS URL - file:///proc/${pid}/ns/net
 func (m *Mechanism) SetNetNSURL(urlString string) {
 	m.GetParameters()[NetNSURL] = urlString
 }


### PR DESCRIPTION
## Description
Modifies `memif` helper:
1. Adds `SetSocketFilename`.
2. Replaces `{Get|Set}SocketFileURL` with `{Get|Set}NetNSURL`.

## Issue link
networkservicemesh/sdk-vpp#370

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
