### PR TITLE
Fix Parse VlanID

### DIFF
--- a/pkg/api/networkservice/mechanisms/vlan/helpers.go
+++ b/pkg/api/networkservice/mechanisms/vlan/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Nordix Foundation.
+// Copyright (c) 2021-2022 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -64,7 +64,7 @@ func (m *Mechanism) GetVlanID() uint32 {
 
 	vid := m.Parameters[ID]
 	// vlan ID range is 0 to 4,095 stored in 12 bit
-	vlanid, err := strconv.ParseInt(vid, 10, 12)
+	vlanid, err := strconv.ParseUint(vid, 10, 12)
 
 	if err != nil {
 		return 0


### PR DESCRIPTION
The VLAN ID string was parsed as 12 bits int (-2048 to 2047) instead 12 bits uint (0 to 4095) which caused an issue when a VLAN ID between 2048 and 4095 was used.

Here is the error raised with NSM 1.3.1
```
VPPApiError: Invalid VLAN (-55): cannot support any of the requested mechanism: all candidates have failed: all forwarders have failed: cannot support any of the requested mechanism
```

With NSM 1.4.0, the host interface would have been injected instead.