### PR TITLE
Add interface name for routes

### DIFF
--- a/pkg/api/networkservice/connectioncontext.proto
+++ b/pkg/api/networkservice/connectioncontext.proto
@@ -29,8 +29,8 @@ message IpNeighbor {
 
 message Route {
     string prefix = 1; /* destination address + prefix in format <address>/<prefix> */
-    string nextHop = 2; /* nexthop ip address - if empty, presume {Src/Dst}IP of same address family
-                           from the opposite end of the link */
+    string nextHop = 2; /* nexthop ip address - if empty, presume {Src/Dst}IP of same address family from the opposite end of the link */
+    string interfaceName = 3;
 }
 
 message IpFamily {


### PR DESCRIPTION
## Description
Add possibility to set interface name for routes. So we can set routes that route not only to nsm interface but to any interface we need.

Signed-off-by: Nikita Skrynnik <nikita.skrynnik@xored.com>