### PR TITLE
Fix GetPrefixIPNet func and delete unnecessary statements in strToIPNet func

### DIFF
--- a/pkg/api/networkservice/ipcontext_helpers.go
+++ b/pkg/api/networkservice/ipcontext_helpers.go
@@ -135,7 +135,16 @@ func contains(prefixes []*net.IPNet, ip net.IP) bool {
 
 // GetPrefixIPNet - GetPrefix() converted to *net.IPNet or nil if empty or cannot be parsed
 func (r *Route) GetPrefixIPNet() *net.IPNet {
-	return strToIPNet(r.GetPrefix())
+	prefix := r.GetPrefix()
+	if prefix == "" {
+		return nil
+	}
+	ip, ipNet, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return nil
+	}
+	ipNet.IP = ip
+	return ipNet
 }
 
 // GetNextHopIP - GetNextHop() converted to net.IP or nil if empty or cannot be parsed
@@ -162,10 +171,9 @@ func strToIPNet(in string) *net.IPNet {
 	if in == "" {
 		return nil
 	}
-	ip, ipNet, err := net.ParseCIDR(in)
+	_, ipNet, err := net.ParseCIDR(in)
 	if err != nil {
 		return nil
 	}
-	ipNet.IP = ip
 	return ipNet
 }


### PR DESCRIPTION
## Description

This PR deletes some unncessary lines](https://github.com/networkservicemesh/api/blob/main/pkg/api/networkservice/ipcontext_helpers.go#L169) from `strToIPNet` function and fixes `GetPrefixIPNet` function that depends on these lines. 