### PR TITLE
qfix: update go to v1.23.3 for update-dependent-repositories-gomod.yaml

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.20.5
+          go-version: 1.23.3
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |


### PR DESCRIPTION
## Motivation

Fixes 


```
Run GOPRIVATE=github.com/networkservicemesh go get -u github.com/networkservicemesh/api@main
go: downloading github.com/networkservicemesh/api v1.14.2-0.20241205110710-[8](https://github.com/networkservicemesh/api/actions/runs/12178499185/job/33968627597#step:7:9)27a859925b7
go: upgraded github.com/networkservicemesh/api v1.13.4-0.20240815101554-fdbfcd84fd0e => v1.14.2-0.20241205110710-827a85[9](https://github.com/networkservicemesh/api/actions/runs/12178499185/job/33968627597#step:7:10)925b7
go: go.mod file indicates go 1.23, but maximum version supported by tidy is 1.20
Error: Process completed with exit code 1.
```

https://github.com/networkservicemesh/api/actions/runs/12178499185