### PR TITLE
Enable dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    groups:
+      gh-actions-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -8,7 +8,7 @@ on:
       - 'ci'
 jobs:
   automerge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot'}}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.actor == 'nsmbot' || github.actor == 'dependabot[bot]')}}
     uses: networkservicemesh/.github/.github/workflows/automerge.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -6,6 +6,7 @@ on:
       - main
 jobs:
   update-dependent-repositories:
+    if: ${{ github.event.commits[0].author.name != 'dependabot[bot]' }}
     strategy:
       matrix:
         repository: [sdk]


### PR DESCRIPTION
This PR enables Dependabot in the repository to automatically check GitHub Actions versions weekly and create pull requests for any outdated dependencies found.