### PR TITLE
Exclude dependabot from automerge due to dependabot alerts

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -8,7 +8,7 @@ on:
       - 'ci'
 jobs:
   automerge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.actor == 'nsmbot' || github.actor == 'dependabot[bot]')}}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' }}
     uses: networkservicemesh/.github/.github/workflows/automerge.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR removes Dependabot actor from the automerge workflow. Dependabot alerts create PRs that are not eligible for automerge, making this adjustment necessary.