### PR TITLE
Fix update-dependent-repositories-gomod toolchain pin

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -45,9 +45,11 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.23.3
+          go-version: 1.25.0
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
+        env:
+          GOTOOLCHAIN: auto
         run: |
           GOPRIVATE=github.com/networkservicemesh go get -u github.com/${{ github.repository }}@main
           go mod tidy


### PR DESCRIPTION
## Problem

After #202 merged (grpc uplift to v1.82.1, which requires go >= 1.25.0),
the `update-dependent-repositories-gomod` workflow failed when trying
to update `sdk`:

```
Run GOPRIVATE=github.com/networkservicemesh go get -u github.com/networkservicemesh/api@main
go: go.mod requires go >= 1.24.0 (running go 1.23.3; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```

The workflow's `actions/setup-go` step was pinned to `1.23.3`, and
without `GOTOOLCHAIN=auto` it refuses to self-upgrade even though a
newer toolchain is available.

## Fix
- Bump the `setup-go` pin to `1.25.0`
- Set `GOTOOLCHAIN=auto` for the update step, so future `go` directive
  bumps in dependent repos (`sdk` and others in the matrix) don't hard-fail
  the same way — Go will download whatever toolchain the target module
  actually needs.

This only touches this repo's own bot workflow; no module/dependency
changes.
